### PR TITLE
Use `time` instead of `chrono` to avoid RUSTSEC-2020-0159

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ regex = "1"
 serde_json = { version = "1", features = ["preserve_order"] }
 base64 = "0.13"
 flate2 = "1"
-chrono = "0.4"
 openssl = "0.10.36"
+time = "0.3.4"
 
 [dev-dependencies]
 doc-comment = "0.3.3"

--- a/src/jwt/jwt_payload_validator.rs
+++ b/src/jwt/jwt_payload_validator.rs
@@ -2,7 +2,6 @@ use std::convert::Into;
 use std::time::SystemTime;
 
 use anyhow::bail;
-use chrono::{DateTime, Utc};
 
 use crate::jwt::JwtPayload;
 use crate::{JoseError, Map, Value};
@@ -178,7 +177,7 @@ impl JwtPayloadValidator {
                 if &not_before > current_time {
                     bail!(
                         "The token is not yet valid: {}",
-                        DateTime::<Utc>::from(not_before)
+                        time::OffsetDateTime::from(not_before),
                     );
                 }
             }
@@ -187,7 +186,7 @@ impl JwtPayloadValidator {
                 if &expires_at <= current_time {
                     bail!(
                         "The token has expired: {}",
-                        DateTime::<Utc>::from(expires_at)
+                        time::OffsetDateTime::from(expires_at),
                     );
                 }
             }
@@ -196,14 +195,14 @@ impl JwtPayloadValidator {
                 if &issued_at < min_issued_time {
                     bail!(
                         "The issued time is too old: {}",
-                        DateTime::<Utc>::from(issued_at)
+                        time::OffsetDateTime::from(issued_at),
                     );
                 }
 
                 if &issued_at > max_issued_time {
                     bail!(
                         "The issued time is too new: {}",
-                        DateTime::<Utc>::from(issued_at)
+                        time::OffsetDateTime::from(issued_at),
                     );
                 }
             }


### PR DESCRIPTION
https://github.com/chronotope/chrono/issues/499

It seems the outputs are consistent (I haven't checked actual output thought)

`fmt::Display` of `chrono::DateTime`
https://docs.rs/chrono/0.4.0/src/chrono/datetime.rs.html#376-380
https://docs.rs/chrono/0.4.0/src/chrono/naive/datetime.rs.html#1330-1334

`fmt::Display` of `time::OffsetDateTime`
https://docs.rs/time/0.3.4/src/time/offset_date_time.rs.html#838-842