### PR TITLE
Fix DER encoding of RSA integers

### DIFF
--- a/src/jwk/alg/rsa.rs
+++ b/src/jwk/alg/rsa.rs
@@ -146,67 +146,7 @@ impl RsaKeyPair {
     /// * `jwk` - A private key that is formatted by a JWK of RSA type.
     pub fn from_jwk(jwk: &Jwk) -> Result<Self, JoseError> {
         (|| -> anyhow::Result<Self> {
-            match jwk.key_type() {
-                val if val == "RSA" => {}
-                val => bail!("A parameter kty must be RSA: {}", val),
-            }
-            let n = match jwk.parameter("n") {
-                Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
-                Some(_) => bail!("A parameter n must be a string."),
-                None => bail!("A parameter n is required."),
-            };
-            let e = match jwk.parameter("e") {
-                Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
-                Some(_) => bail!("A parameter e must be a string."),
-                None => bail!("A parameter e is required."),
-            };
-            let d = match jwk.parameter("d") {
-                Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
-                Some(_) => bail!("A parameter d must be a string."),
-                None => bail!("A parameter d is required."),
-            };
-            let p = match jwk.parameter("p") {
-                Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
-                Some(_) => bail!("A parameter p must be a string."),
-                None => bail!("A parameter p is required."),
-            };
-            let q = match jwk.parameter("q") {
-                Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
-                Some(_) => bail!("A parameter q must be a string."),
-                None => bail!("A parameter q is required."),
-            };
-            let dp = match jwk.parameter("dp") {
-                Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
-                Some(_) => bail!("A parameter dp must be a string."),
-                None => bail!("A parameter dp is required."),
-            };
-            let dq = match jwk.parameter("dq") {
-                Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
-                Some(_) => bail!("A parameter dq must be a string."),
-                None => bail!("A parameter dq is required."),
-            };
-            let qi = match jwk.parameter("qi") {
-                Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
-                Some(_) => bail!("A parameter qi must be a string."),
-                None => bail!("A parameter qi is required."),
-            };
-
-            let mut builder = DerBuilder::new();
-            builder.begin(DerType::Sequence);
-            {
-                builder.append_integer_from_u8(0); // version
-                builder.append_integer_from_be_slice(&n, false); // n
-                builder.append_integer_from_be_slice(&e, false); // e
-                builder.append_integer_from_be_slice(&d, false); // d
-                builder.append_integer_from_be_slice(&p, false); // p
-                builder.append_integer_from_be_slice(&q, false); // q
-                builder.append_integer_from_be_slice(&dp, false); // d mod (p-1)
-                builder.append_integer_from_be_slice(&dq, false); // d mod (q-1)
-                builder.append_integer_from_be_slice(&qi, false); // (inverse of q) mod p
-            }
-            builder.end();
-
-            let pkcs8 = Self::to_pkcs8(&builder.build(), false);
+            let pkcs8 = Self::jwk_to_pkcs8(jwk)?;
             let private_key = PKey::private_key_from_der(&pkcs8)?;
             let algorithm = jwk.algorithm().map(|val| val.to_string());
             let key_id = jwk.key_id().map(|val| val.to_string());
@@ -339,6 +279,70 @@ impl RsaKeyPair {
         Some(())
     }
 
+    fn jwk_to_pkcs8(jwk: &Jwk) -> anyhow::Result<Vec<u8>> {
+        match jwk.key_type() {
+            val if val == "RSA" => {}
+            val => bail!("A parameter kty must be RSA: {}", val),
+        }
+        let n = match jwk.parameter("n") {
+            Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
+            Some(_) => bail!("A parameter n must be a string."),
+            None => bail!("A parameter n is required."),
+        };
+        let e = match jwk.parameter("e") {
+            Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
+            Some(_) => bail!("A parameter e must be a string."),
+            None => bail!("A parameter e is required."),
+        };
+        let d = match jwk.parameter("d") {
+            Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
+            Some(_) => bail!("A parameter d must be a string."),
+            None => bail!("A parameter d is required."),
+        };
+        let p = match jwk.parameter("p") {
+            Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
+            Some(_) => bail!("A parameter p must be a string."),
+            None => bail!("A parameter p is required."),
+        };
+        let q = match jwk.parameter("q") {
+            Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
+            Some(_) => bail!("A parameter q must be a string."),
+            None => bail!("A parameter q is required."),
+        };
+        let dp = match jwk.parameter("dp") {
+            Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
+            Some(_) => bail!("A parameter dp must be a string."),
+            None => bail!("A parameter dp is required."),
+        };
+        let dq = match jwk.parameter("dq") {
+            Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
+            Some(_) => bail!("A parameter dq must be a string."),
+            None => bail!("A parameter dq is required."),
+        };
+        let qi = match jwk.parameter("qi") {
+            Some(Value::String(val)) => util::decode_base64_urlsafe_no_pad(val)?,
+            Some(_) => bail!("A parameter qi must be a string."),
+            None => bail!("A parameter qi is required."),
+        };
+
+        let mut builder = DerBuilder::new();
+        builder.begin(DerType::Sequence);
+        {
+            builder.append_integer_from_u8(0); // version
+            builder.append_integer_from_be_slice(&n, true); // n
+            builder.append_integer_from_be_slice(&e, true); // e
+            builder.append_integer_from_be_slice(&d, true); // d
+            builder.append_integer_from_be_slice(&p, true); // p
+            builder.append_integer_from_be_slice(&q, true); // q
+            builder.append_integer_from_be_slice(&dp, true); // d mod (p-1)
+            builder.append_integer_from_be_slice(&dq, true); // d mod (q-1)
+            builder.append_integer_from_be_slice(&qi, true); // (inverse of q) mod p
+        }
+        builder.end();
+
+        Ok(Self::to_pkcs8(&builder.build(), false))
+    }
+
     pub(crate) fn to_pkcs8(input: &[u8], is_public: bool) -> Vec<u8> {
         let mut builder = DerBuilder::new();
         builder.begin(DerType::Sequence);
@@ -382,7 +386,7 @@ impl KeyPair for RsaKeyPair {
     }
 
     fn to_der_private_key(&self) -> Vec<u8> {
-        Self::to_pkcs8(&self.to_raw_private_key(), false)
+        self.private_key.private_key_to_pkcs8().unwrap()
     }
 
     fn to_der_public_key(&self) -> Vec<u8> {
@@ -427,6 +431,19 @@ mod tests {
     use anyhow::Result;
 
     use super::RsaKeyPair;
+
+    #[test]
+    fn test_jwk_to_pkcs8() -> Result<()> {
+        for bits in vec![1024, 2048, 4096] {
+            let key_pair_1 = RsaKeyPair::generate(bits)?;
+            let der_private = key_pair_1.to_der_private_key();
+            let jwk_key_pair = key_pair_1.to_jwk_key_pair();
+
+            assert_eq!(der_private, RsaKeyPair::jwk_to_pkcs8(&jwk_key_pair).unwrap());
+        }
+ 
+        Ok(())
+    }
 
     #[test]
     fn test_rsa_jwt() -> Result<()> {

--- a/src/jwk/alg/rsapss.rs
+++ b/src/jwk/alg/rsapss.rs
@@ -326,14 +326,14 @@ impl RsaPssKeyPair {
             builder.begin(DerType::Sequence);
             {
                 builder.append_integer_from_u8(0); // version
-                builder.append_integer_from_be_slice(&n, false); // n
-                builder.append_integer_from_be_slice(&e, false); // e
-                builder.append_integer_from_be_slice(&d, false); // d
-                builder.append_integer_from_be_slice(&p, false); // p
-                builder.append_integer_from_be_slice(&q, false); // q
-                builder.append_integer_from_be_slice(&dp, false); // d mod (p-1)
-                builder.append_integer_from_be_slice(&dq, false); // d mod (q-1)
-                builder.append_integer_from_be_slice(&qi, false); // (inverse of q) mod p
+                builder.append_integer_from_be_slice(&n, true); // n
+                builder.append_integer_from_be_slice(&e, true); // e
+                builder.append_integer_from_be_slice(&d, true); // d
+                builder.append_integer_from_be_slice(&p, true); // p
+                builder.append_integer_from_be_slice(&q, true); // q
+                builder.append_integer_from_be_slice(&dp, true); // d mod (p-1)
+                builder.append_integer_from_be_slice(&dq, true); // d mod (q-1)
+                builder.append_integer_from_be_slice(&qi, true); // (inverse of q) mod p
             }
             builder.end();
 

--- a/src/jws/alg/rsassa_pss.rs
+++ b/src/jws/alg/rsassa_pss.rs
@@ -349,8 +349,8 @@ impl RsassaPssJwsAlgorithm {
             let mut builder = DerBuilder::new();
             builder.begin(DerType::Sequence);
             {
-                builder.append_integer_from_be_slice(&n, false); // n
-                builder.append_integer_from_be_slice(&e, false); // e
+                builder.append_integer_from_be_slice(&n, true); // n
+                builder.append_integer_from_be_slice(&e, true); // e
             }
             builder.end();
 

--- a/src/util/der/der_builder.rs
+++ b/src/util/der/der_builder.rs
@@ -51,8 +51,8 @@ impl DerBuilder {
         self.append(DerType::Integer, None, &vec);
     }
 
-    pub fn append_integer_from_be_slice(&mut self, value: &[u8], sign: bool) {
-        let prefix = if sign && value.len() > 0 && value[0] & 0b10000000 != 0 {
+    pub fn append_integer_from_be_slice(&mut self, value: &[u8], unsigned: bool) {
+        let prefix = if unsigned && value.len() > 0 && value[0] & 0b10000000 != 0 {
             Some(0)
         } else {
             None


### PR DESCRIPTION
RSA integers with the high bit set in the first byte were not padded resulting in those numbers being incorrectly interpreted as negative. This commit also adds two new test cases to enforce canonical conversion of RSA JWKs to DER.

Closes #49