### PR TITLE
Add claims-as-{ints,floats} crate features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josekit"
-version = "0.10.3"
+version = "0.10.4"
 description = "JOSE (Javascript Object Signing and Encryption) library for Rust."
 repository = "https://github.com/hidekatsu-izuno/josekit-rs"
 readme = "README.md"
@@ -13,7 +13,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["claims-as-ints"]
+claims-as-floats = []
+claims-as-ints = []
 vendored = ["openssl/vendored"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ JOSE (Javascript Object Signing and Encryption: JWT, JWS, JWE, JWA, JWK) library
 
 ```toml
 [dependencies]
-josekit = "0.10.3"
+josekit = "0.10.4"
 ```
 
 This library depends on OpenSSL 1.1.1 or above DLL. Read more about [Crate openssl](https://docs.rs/openssl/). 
@@ -18,6 +18,9 @@ sudo apt install build-essential pkg-config libssl-dev
 cd josekit-rs
 cargo build --release
 ```
+### Crate Features
+1. `claims-as-ints` [Default] - Claims are processed as integers
+1. `claims-as-floats` - Claims are processed as floats
 
 <!-- 
 ## Publish


### PR DESCRIPTION
This adds in feature flags for the behavior described [here](https://github.com/hidekatsu-izuno/josekit-rs/issues/53). By default, claims are handled as integers